### PR TITLE
fix units typo

### DIFF
--- a/low-level-api-proposal.py
+++ b/low-level-api-proposal.py
@@ -193,7 +193,7 @@ class CollisionInducedAbsorptionAbstractBaseClass(object):
             kwargs: Extra optional arguments to configure specific models.
 
         Returns:
-            Array of absorption coefficients [m4] on input wavenumber grid.
+            Array of absorption coefficients [m5] on input wavenumber grid.
         """
         raise NotImplementedError("you must override this.")
 
@@ -219,7 +219,7 @@ class HitranCIA(CollisionInducedAbsorptionAbstractBaseClass):
             grid: Spectral grid array [cm-1].
 
         Returns:
-            Array of absorption coefficients [m4] on input wavenumber grid.
+            Array of absorption coefficients [m5] on input wavenumber grid.
         """
         pass
 


### PR DESCRIPTION
Fixes a mistake in the documentation.  The units of collision-induced absorption coefficients are [m<sup>5</sup>], not [m<sup>4</sup>].  Another option we could/should explore is multiplying the absorption coefficients by the number density [m<sup>-3</sup>], so that all low level absorption coefficient functions return their results in [m<sup>-1</sup>].  The number density can be calculated with a simple function like:
```python
def number_density(pressure, temperature, volume_mixing_ratio):
    """Calculates number density using the ideal gas law.

    Args:
        pressure: Pressure [Pa].
        temperature: Temperature [K].
        volume_mixing_ratio: Volume-mixing ratio [mol mol-1].

    Returns:
        Number density [m-3].
    """
    kb = 1.38064852e-23  # Boltzmann constant [J K-1].
    return pressure*volume_mixing_ratio/(kb*temperature)
```